### PR TITLE
new bap endpoint required for Guest Access

### DIFF
--- a/mr-docs/guides/admin-network-requirements.md
+++ b/mr-docs/guides/admin-network-requirements.md
@@ -42,6 +42,7 @@ If you have specialized needs and/or scale, see the [Teams comprehensive list](/
 
 #### Power Apps
 - service.powerapps.com
+- api.bap.microsoft.com
 - TCP: 80, 443
 
 #### Documentation 


### PR DESCRIPTION
v7.4 of Guides HoloLens requires new bap endpoint for guest tenant discovery